### PR TITLE
Remove unnecessary MOODLE_INTERNAL and @codingStandardsIgnoreLine

### DIFF
--- a/classes/componentsupport/forum_component.php
+++ b/classes/componentsupport/forum_component.php
@@ -280,7 +280,6 @@ SQL;
         $discussions = '{' . $this->type . '_discussions}';
         $poststable = '{' . $this->type . '_posts}';
         $forum = '{' . $this->type . '}';
-        $params = [$id];
         if ($table === $this->type . '_posts') {
             $params = [$id];
             $sql = <<<SQL

--- a/classes/version_information.php
+++ b/classes/version_information.php
@@ -23,9 +23,6 @@
  */
 
 namespace tool_ally;
-// Prepare for code checker update. Will be removed on INT-17966.
-// @codingStandardsIgnoreLine
-defined('MOODLE_INTERNAL') || die();
 
 use core_component,
     core_plugin_manager,

--- a/lib.php
+++ b/lib.php
@@ -20,9 +20,6 @@
  * @copyright Copyright (c) 2017 Open LMS (https://www.openlms.net) / 2023 Anthology Inc. and its affiliates
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-// Prepare for code checker update. Will be removed on INT-17966.
-// @codingStandardsIgnoreLine
-defined('MOODLE_INTERNAL') || die();
 
 use tool_ally\file_processor,
     tool_ally\local_file,


### PR DESCRIPTION
This PR will remove unnecessary MOODLE_INTERNAL and @codingStandardsIgnoreLine annotations for Moodle Code Checker 3.1.0 and above.