### PR TITLE
Fix undefined property $token

### DIFF
--- a/classes/local.php
+++ b/classes/local.php
@@ -222,7 +222,7 @@ class local {
      * @throws \dml_exception
      * @throws \webservice_access_exception
      */
-    public static function get_ws_token() {
+    public static function  get_ws_token() {
         $allyuser = self::get_ally_web_user();
         if (!$allyuser) {
             $msg = 'Ally web user (ally_webuser) does not exist. Has auto configure been run?';
@@ -239,6 +239,11 @@ class local {
             throw new \webservice_access_exception($msg);
         }
         $wstoken = reset($tokens);
+
+        // If no token was found - as in PHPUnit tests - return an empty string.
+        if (!isset($wstoken->token)) {
+            $wstoken->token = "";
+        }
         return $wstoken;
     }
 


### PR DESCRIPTION
If no token string was found - as in PHPUnit tests - return an empty string.
This will fix #96.